### PR TITLE
Allow `polyphony.compiler` to be executed

### DIFF
--- a/polyphony/compiler/__main__.py
+++ b/polyphony/compiler/__main__.py
@@ -800,3 +800,7 @@ def main():
         print(e)
     except Exception as e:
         raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change allows for `polyphony.compiler` to be run as a script
when polyphony has been installed:

    $ python3 -m polyphony.compiler

It can often be preferable to execute installed packages in this
manner as it ensures the script is executed from the correct
path and will behave properly with virtual environments.

It is also 'correct' for the \_\_main__ module in a package to be
runnable as a script.